### PR TITLE
Implement deterministic identity colors using fingerprints

### DIFF
--- a/chat/message/identity.go
+++ b/chat/message/identity.go
@@ -5,6 +5,7 @@ type Identifier interface {
 	ID() string
 	SetID(string)
 	Name() string
+	Fingerprint() string
 }
 
 // SimpleID is a simple Identifier implementation used for testing.
@@ -18,6 +19,11 @@ func (i SimpleID) ID() string {
 // SetID is a no-op
 func (i SimpleID) SetID(s string) {
 	// no-op
+}
+
+// Fingerprint returns an empty string
+func (i SimpleID) Fingerprint() string {
+	return ""
 }
 
 // Name returns the ID

--- a/chat/message/user_test.go
+++ b/chat/message/user_test.go
@@ -53,8 +53,7 @@ func TestRenderTimestamp(t *testing.T) {
 	u.Send(m)
 	u.HandleMsg(u.ConsumeOne())
 
-	s.Read(&actual)
-	expected = []byte(`[38;05;245mAA:BB` + Reset + `  [[38;05;88mfoo[0m] hello` + Newline)
+	expected = []byte(`[38;05;245mAA:BB` + Reset + `  [[38;05;117mfoo[0m] hello` + Newline)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Wrong screen output:\n Got: `%q`;\nWant: `%q`", actual, expected)
 	}

--- a/chat/message/user_test.go
+++ b/chat/message/user_test.go
@@ -53,7 +53,8 @@ func TestRenderTimestamp(t *testing.T) {
 	u.Send(m)
 	u.HandleMsg(u.ConsumeOne())
 
-	expected = []byte(`[38;05;245mAA:BB` + Reset + `  [[38;05;117mfoo[0m] hello` + Newline)
+	s.Read(&actual)
+	expected = []byte(`[38;05;245mAA:BB` + Reset + `  [38;05;117mfoo[0m: hello` + Newline)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Wrong screen output:\n Got: `%q`;\nWant: `%q`", actual, expected)
 	}

--- a/host_test.go
+++ b/host_test.go
@@ -60,7 +60,7 @@ func TestHostGetPrompt(t *testing.T) {
 	u := message.NewUser(&Identity{id: "foo"})
 
 	actual = GetPrompt(u)
-	expected = "[foo] "
+	expected = "foo> "
 	if actual != expected {
 		t.Errorf("Invalid host prompt:\n Got: %q;\nWant: %q", actual, expected)
 	}
@@ -69,7 +69,7 @@ func TestHostGetPrompt(t *testing.T) {
 		Theme: &message.Themes[0],
 	})
 	actual = GetPrompt(u)
-	expected = "[\033[38;05;88mfoo\033[0m] "
+	expected = "\x1b[38;05;117mfoo\x1b[0m> "
 	if actual != expected {
 		t.Errorf("Invalid host prompt:\n Got: %q;\nWant: %q", actual, expected)
 	}
@@ -113,7 +113,7 @@ func TestHostNameCollision(t *testing.T) {
 			actual = scanner.Text()
 			// This check has to happen second because prompt doesn't always
 			// get set before the first message.
-			if !strings.HasPrefix(actual, "[foo] ") {
+			if !strings.HasPrefix(actual, "foo> ") {
 				t.Errorf("First client failed to get 'foo' name: %q", actual)
 			}
 			actual = stripPrompt(actual)
@@ -145,7 +145,7 @@ func TestHostNameCollision(t *testing.T) {
 		scanner.Scan()
 
 		actual := scanner.Text()
-		if !strings.HasPrefix(actual, "[Guest1] ") {
+		if !strings.HasPrefix(actual, "Guest1> ") {
 			t.Errorf("Second client did not get Guest1 name: %q", actual)
 		}
 		return nil

--- a/identity.go
+++ b/identity.go
@@ -41,11 +41,16 @@ func (i *Identity) SetID(id string) {
 
 // Fingerprint returns the user's public key fingerprint. Returns an empty string if non is set
 func (i *Identity) Fingerprint() string {
-	if i.PublicKey() == nil {
+	if i.Connection == nil {
 		return ""
 	}
 
-	return sshd.Fingerprint(i.PublicKey())
+	publicKey := i.PublicKey()
+	if publicKey == nil {
+		return ""
+	}
+
+	return sshd.Fingerprint(publicKey)
 }
 
 // SetName Changes the Identity's name

--- a/identity.go
+++ b/identity.go
@@ -39,6 +39,15 @@ func (i *Identity) SetID(id string) {
 	i.id = id
 }
 
+// Fingerprint returns the user's public key fingerprint. Returns an empty string if non is set
+func (i *Identity) Fingerprint() string {
+	if i.PublicKey() == nil {
+		return ""
+	}
+
+	return sshd.Fingerprint(i.PublicKey())
+}
+
 // SetName Changes the Identity's name
 func (i *Identity) SetName(name string) {
 	i.SetID(name)


### PR DESCRIPTION
I've implemented deterministic identity colors using the public key fingerprint of the user.

The ssh-chat code seems to handle cases where the public key is not set (which I don't know when that would happen), so there's also a fallback on using the user's name as the input for the color generation.

The "color generator" itself simply uses a hash of the input, converted to an integer seed. The generator is then used to generate a random integer, which is in line with the previous code.

Two things worth mentioning:

1. ssh-chat seems to (naively) use the color code directly as ANSI colors. Won't this potentially lead to overflow? There are only so many colors defined. A simple solution would be using modulo. I might have missed something in the code, though.

2. The concurrency tests don't pass after this change and I can't figure out why. There seems to be a null pointer exception, but I can't relate my changes to potential issues. 

And as always,
> it works great on my computer